### PR TITLE
ユーザーにポイントカラム追加、ポイント加算ロジックの実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -33,11 +33,12 @@ class CommentsController < ApplicationController
 
   def set_best_comment
     @comment = Comment.find(params[:id])
-    if @comment.post.best_comment.present? || current_user != @comment.post.user
+    if @comment.post.best_comment.present? || current_user != @comment.post.user || @comment.post.user == @comment.user
       redirect_to post_path(@comment.post), alert: '権限がありません。'
     end
 
     @comment.post.update(best_comment: @comment)
+    @comment.user.increment!(:points, 5)
     redirect_to post_path(@comment.post), notice: 'ベストアンサーを選びました。'
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,6 +21,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
+      current_user.increment!(:points, 1)
       redirect_to root_path
     else
       render :new, status: :unprocessable_entity

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -2,7 +2,7 @@
   <% if post.best_comment_id == comment.id %>
     <i>ベストアンサー</i>
   <% end %>
-  <% if current_user == post.user && post.best_comment_id.nil? %>
+  <% if current_user == post.user && post.best_comment_id.nil? && comment.user != post.user %>
     <%= button_to "ベストアンサーに選ぶ", set_best_comment_comment_path(comment), method: :patch %>
   <% end %>
   <p>回答者：<%= comment.user.name %></p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -45,5 +45,10 @@
         </div>
       </div>
     </div>
+
+    <% if current_user %>
+      <p><%= current_user.name %></p>
+      <p><%= current_user.points %></p>
+    <% end %>
   </div>
 </header>

--- a/db/migrate/20250824004136_add_points_to_users.rb
+++ b/db/migrate/20250824004136_add_points_to_users.rb
@@ -1,0 +1,5 @@
+class AddPointsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :points, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_23_082052) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_24_004136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_23_082052) do
     t.datetime "remember_created_at"
     t.string "provider"
     t.string "uid"
+    t.integer "points", default: 0, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 概要
### ポイントカラムの追加
Closes #20 
- ユーザーテーブルにポイントを格納するためのカラムを追加

Closes #21 
- ユーザーが投稿した時にinclementでポイントを追加するロジックをPostコントローラー上に追加
- ユーザーのコメントがベストアンサーに選ばれた際にポイントを追加するロジックをCommentコントローラー上に追加